### PR TITLE
Add package.json for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,18 @@ yes
 
 # installation
 
+from source:
+
 ``` bash
 $ git clone https://github.com/ashaindlin/git-fem.git
 $ cd git-fem
 $ sudo make install
+```
+
+via [npm](https://nodejs.org/en/download/):
+
+```bash
+$ npm install git-fem -g
 ```
 
 # usage

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "git-fem",
+  "version": "1.0.0",
+  "description": "change your `master` branch to `mistress`",
+  "bin": {
+    "git-fem": "./git-fem.sh"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ashaindlin/git-fem.git"
+  },
+  "keywords": [
+    "git",
+    "github",
+    "femme",
+    "feminist",
+    "feminism",
+    "tool",
+    "utility",
+    "script"
+  ],
+  "author": "ashaindlin",
+  "license": "MIT",
+  "homepage": "https://github.com/ashaindlin/git-fem"
+}


### PR DESCRIPTION
This is awesome! I saw it was a few years old but with plenty of stars, so I figured it would be worth hosting on npm for others to find and use more easily.

To publish publicly (after [installing npm](https://nodejs.org/en/download/)) you can just run `npm publish`.

The install step that I added to the README will link the `git-fem` binary automatically, so no need to clone or `make install` in order to use it. See docs [here](https://docs.npmjs.com/files/package.json#bin).

I think `license` is required, so I defaulted to [MIT](https://opensource.org/licenses/MIT) which seems to be the de-facto standard for open source hobby projects. Feel free to tweak it before merging.